### PR TITLE
Address UI on the fullscreen map

### DIFF
--- a/Core/Chat/DrawChatSystem.cs
+++ b/Core/Chat/DrawChatSystem.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using ChatPlus.Common.Configs;
 using ChatPlus.Core.Features.TypingIndicators;
 using ChatPlus.Core.Features.Uploads;
+using ChatPlus.Core.Helpers;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.GameContent;
@@ -30,6 +31,8 @@ internal class DrawChatSystem : ModSystem
         }
 
         On_Main.DrawPlayerChat += DrawChat;
+        On_Main.DrawPlayerChat += DrawUIInFullscreenMap;
+        On_Main.DrawPendingMouseText += DrawTopMostUIInFullscreenMap;
         On_RemadeChatMonitor.DrawChat += DrawMonitor;
     }
 
@@ -41,6 +44,8 @@ internal class DrawChatSystem : ModSystem
         }
 
         On_Main.DrawPlayerChat -= DrawChat;
+        On_Main.DrawPlayerChat -= DrawUIInFullscreenMap;
+        On_Main.DrawPendingMouseText -= DrawTopMostUIInFullscreenMap;
         On_RemadeChatMonitor.DrawChat -= DrawMonitor;
     }
 
@@ -92,6 +97,26 @@ internal class DrawChatSystem : ModSystem
         finally
         {
             Main.screenHeight = oldH;
+        }
+    }
+
+    private void DrawUIInFullscreenMap(On_Main.orig_DrawPlayerChat orig, Main self)
+    {
+        orig(self);
+
+        if (Main.mapFullscreen)
+        {
+            DrawSystemsInFullscreenMap.Draw();
+        }
+    }
+
+    private void DrawTopMostUIInFullscreenMap(On_Main.orig_DrawPendingMouseText orig)
+    {
+        orig();
+
+        if (Main.mapFullscreen)
+        {
+            DrawSystemsInFullscreenMap.DrawTopMostSystems();
         }
     }
 

--- a/Core/Features/ModIcons/ModInfo/TopMostModInfoOverlaySystem.cs
+++ b/Core/Features/ModIcons/ModInfo/TopMostModInfoOverlaySystem.cs
@@ -17,15 +17,17 @@ public class TopMostModInfoOverlaySystem : ModSystem
     {
         layers.Add(new LegacyGameInterfaceLayer(
             "ChatPlus: ModInfoOverlay_TopMost",
-            () =>
-            {
-                var mod = HoveredModOverlay.Consume();
-                if (mod != null)
-                {
-                    ModInfoDrawer.Draw(Main.spriteBatch, mod);
-                }
-                return true;
-            },
+            Draw,
             InterfaceScaleType.UI));
+    }
+
+    public bool Draw()
+    {
+        var mod = HoveredModOverlay.Consume();
+        if (mod != null)
+        {
+            ModInfoDrawer.Draw(Main.spriteBatch, mod);
+        }
+        return true;
     }
 }

--- a/Core/Features/PlayerIcons/PlayerInfo/TopMostPlayerInfoOverlaySystem.cs
+++ b/Core/Features/PlayerIcons/PlayerInfo/TopMostPlayerInfoOverlaySystem.cs
@@ -17,19 +17,21 @@ public class TopMostPlayerInfoOverlaySystem : ModSystem
         // Insert at the very end to be above everything.
         layers.Add(new LegacyGameInterfaceLayer(
             "ChatPlus: PlayerInfoOverlay_TopMost",
-            () =>
-            {
-                int idx = HoveredPlayerOverlay.Consume();
-                if (idx >= 0 && idx < Main.maxPlayers)
-                {
-                    var player = Main.player[idx];
-                    if (player?.active == true)
-                    {
-                        PlayerInfoDrawer.Draw(Main.spriteBatch, player);
-                    }
-                }
-                return true;
-            },
+            Draw,
             InterfaceScaleType.UI));
+    }
+
+    public bool Draw()
+    {
+        int idx = HoveredPlayerOverlay.Consume();
+        if (idx >= 0 && idx < Main.maxPlayers)
+        {
+            var player = Main.player[idx];
+            if (player?.active == true)
+            {
+                PlayerInfoDrawer.Draw(Main.spriteBatch, player);
+            }
+        }
+        return true;
     }
 }

--- a/Core/Features/Scrollbar/ChatScrollSystem.cs
+++ b/Core/Features/Scrollbar/ChatScrollSystem.cs
@@ -56,15 +56,17 @@ public class ChatScrollSystem : ModSystem
         {
             layers.Insert(index, new LegacyGameInterfaceLayer(
                 "ChatPlus: Chat Scrollbar",
-                () =>
-                {
-                    int show = Math.Clamp((int)Conf.C.ChatsVisible, 10, 20);
-                    bool moreThanVisible = ChatScrollList.GetTotalLines() > show;
-                    if (Main.drawingPlayerChat && chatScrollUI?.CurrentState != null && Conf.C.Scrollbar && moreThanVisible)
-                        chatScrollUI.Draw(Main.spriteBatch, Main.gameTimeCache);
-                    return true;
-                },
+                Draw,
                 InterfaceScaleType.UI));
         }
+    }
+
+    public bool Draw()
+    {
+        int show = Math.Clamp((int)Conf.C.ChatsVisible, 10, 20);
+        bool moreThanVisible = ChatScrollList.GetTotalLines() > show;
+        if (Main.drawingPlayerChat && chatScrollUI?.CurrentState != null && Conf.C.Scrollbar && moreThanVisible)
+            chatScrollUI.Draw(Main.spriteBatch, Main.gameTimeCache);
+        return true;
     }
 }

--- a/Core/Features/Uploads/UploadInfo/TopMostUploadInfoOverlaySystem.cs
+++ b/Core/Features/Uploads/UploadInfo/TopMostUploadInfoOverlaySystem.cs
@@ -20,16 +20,18 @@ public class TopMostUploadInfoOverlaySystem : ModSystem
     {
         layers.Add(new LegacyGameInterfaceLayer(
             "ChatPlus: UploadHoverOverlay_TopMost",
-            () =>
-            {
-                var tex = HoveredUploadOverlay.Consume();
-                if (tex != null)
-                {
-                    DrawUploadPreview(Main.spriteBatch, tex);
-                }
-                return true;
-            },
+            Draw,
             InterfaceScaleType.UI));
+    }
+
+    public bool Draw()
+    {
+        var tex = HoveredUploadOverlay.Consume();
+        if (tex != null)
+        {
+            DrawUploadPreview(Main.spriteBatch, tex);
+        }
+        return true;
     }
 
     private static void DrawUploadPreview(SpriteBatch sb, Texture2D tex)

--- a/Core/Helpers/DrawSystemsInFullscreenMap.cs
+++ b/Core/Helpers/DrawSystemsInFullscreenMap.cs
@@ -1,20 +1,18 @@
-﻿using Microsoft.Xna.Framework.Graphics;
+﻿using ChatPlus.Core.Features.ModIcons;
+using ChatPlus.Core.Features.PlayerIcons.PlayerInfo;
+using ChatPlus.Core.Features.Scrollbar;
+using ChatPlus.Core.Features.Uploads.UploadInfo;
+using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ModLoader;
 
 namespace ChatPlus.Core.Helpers;
 internal class DrawSystemsInFullscreenMap : ModSystem
 {
-    public override void PostDrawFullscreenMap(ref string mouseText)
+    public static void Draw()
     {
-        base.PostDrawFullscreenMap(ref mouseText);
-        //return;
-
-        // restart SB
-        Main.spriteBatch.End();
-        Main.spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None, RasterizerState.CullNone, null, Main.UIScaleMatrix);
-
         var sm = ChatPlus.StateManager;
+        
         sm.CommandSystem?.ui?.Draw(Main.spriteBatch, Main._drawInterfaceGameTime);
         sm.ColorSystem?.ui?.Draw(Main.spriteBatch, Main._drawInterfaceGameTime);
         sm.CustomTagSystem?.ui?.Draw(Main.spriteBatch, Main._drawInterfaceGameTime);
@@ -26,9 +24,13 @@ internal class DrawSystemsInFullscreenMap : ModSystem
         sm.PlayerIconSystem?.ui?.Draw(Main.spriteBatch, Main._drawInterfaceGameTime);
         sm.UploadSystem?.ui?.Draw(Main.spriteBatch, Main._drawInterfaceGameTime);
 
-        // restart SB
-        Main.spriteBatch.End();
-        Main.spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None, RasterizerState.CullNone);
+        ModContent.GetInstance<ChatScrollSystem>().Draw();
     }
 
+    public static void DrawTopMostSystems()
+    {
+        ModContent.GetInstance<TopMostPlayerInfoOverlaySystem>().Draw();
+        ModContent.GetInstance<TopMostUploadInfoOverlaySystem>().Draw();
+        ModContent.GetInstance<TopMostModInfoOverlaySystem>().Draw();
+    }
 }


### PR DESCRIPTION
### What is the bug?
The UI draw ordering on the fullscreen map did not match that of the normal world. #1 for context.

### How did you fix the bug?
Detoured both `Main.DrawPlayerChat()` and `DrawPendingMouseText()` to insert the proper draw methods at the appropriate times. 
Basically drawing on the map does not use the traditional InterfaceLayer approach. tModLoader has a hook for this `PostDrawFullscreenMap()`, but it is called too early for the purposes of this mod, which is to draw things on top of the chat. Effectively with these new edits drawing in the fullscreen map becomes:
``` c
// Abbreviated from Main.DoDraw()
DrawMap(); // vanilla
DrawPlayerChat(); // vanilla
DrawUIInFullscreenMap(); // modded: draw all scrollable panels and such
DrawPendingMouseText(); // vanilla: this actually draws a vanilla interface layer, the one responsible for item tooltip text
DrawTopMostUIInFullscreenMap(); // modded: this has to be called last because it is supposed to be after all interface layers
```


### Are there alternatives to your fix?
For simplicity I chose to just use detours, but this abuses the fact that vanilla doesn't call those functions very often. The proper approach would be to IL edit Main.DoDraw() to what the above shows.

### Future work

1. Using the scroll wheel in a UI should not zoom the map.
2. Some UI elements can be clicked which opens a menu in the game. This forces the user to exit the fullscreen map to view it, not exactly intuitive. Solutions are to close the map automatically which would reveal the additional UI, or render it on top the fullscreen map, don't know which one is best.  
3. Anything else I missed.