### PR TITLE
Prefer async loading

### DIFF
--- a/Core/Features/Items/ItemElement.cs
+++ b/Core/Features/Items/ItemElement.cs
@@ -1,5 +1,6 @@
 using ChatPlus.Core.UI;
 using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
 using Terraria;
 using Terraria.GameContent;
 using Terraria.ModLoader.UI;
@@ -24,6 +25,11 @@ namespace ChatPlus.Core.Features.Items
 
             var dims = GetDimensions();
             Vector2 pos = dims.Position();
+
+            if (TextureAssets.Item[item.ID] is var asset && asset.State == AssetState.NotLoaded)
+            {
+                Main.Assets.Request<Texture2D>(asset.Name);
+            }
 
             // Render tag
             string tag = item.Tag;

--- a/Core/Features/ModIcons/ModIconSnippet.cs
+++ b/Core/Features/ModIcons/ModIconSnippet.cs
@@ -163,13 +163,13 @@ public sealed class ModIconSnippet : TextSnippet
         // Priority: icon_small.* -> icon.*
         if (mod.FileExists("icon_small.png") || mod.FileExists("icon_small.rawimg"))
         {
-            tex = mod.Assets.Request<Texture2D>("icon_small", AssetRequestMode.ImmediateLoad).Value;
+            tex = mod.Assets.Request<Texture2D>("icon_small").Value;
             return tex != null;
         }
 
         if (mod.FileExists("icon.png"))
         {
-            tex = mod.Assets.Request<Texture2D>("icon", AssetRequestMode.ImmediateLoad).Value;
+            tex = mod.Assets.Request<Texture2D>("icon").Value;
             return tex != null;
         }
 

--- a/Core/Features/Stats/ModStats/ModInfoDrawer.cs
+++ b/Core/Features/Stats/ModStats/ModInfoDrawer.cs
@@ -180,11 +180,11 @@ public static class ModInfoDrawer
 
         // Priority: icon_workshop
         if (mod.FileExists("icon_workshop.rawimg"))
-            tex = mod.Assets.Request<Texture2D>("icon_workshop", AssetRequestMode.ImmediateLoad).Value;
+            tex = mod.Assets.Request<Texture2D>("icon_workshop").Value;
         else if (mod.FileExists("icon.png"))
-            tex = mod.Assets.Request<Texture2D>("icon", AssetRequestMode.ImmediateLoad).Value;
+            tex = mod.Assets.Request<Texture2D>("icon").Value;
         else if (mod.FileExists("icon_small.rawimg"))
-            tex = mod.Assets.Request<Texture2D>("icon_small", AssetRequestMode.ImmediateLoad).Value;
+            tex = mod.Assets.Request<Texture2D>("icon_small").Value;
 
         if (tex != null)
         {


### PR DESCRIPTION
Some content like mod icons and items were requested using `ImmediateLoad`. This uses `AsyncLoad` instead to make the UI less laggy. This noticeably helps with the item panel when scrolling quickly.