### PR TITLE
Delay ItemManager until items are fully loaded

### DIFF
--- a/Core/Features/Items/ItemManager.cs
+++ b/Core/Features/Items/ItemManager.cs
@@ -8,7 +8,7 @@ namespace ChatPlus.Core.Features.Items
     {
         public static List<ItemEntry> Items { get; private set; } = [];
 
-        public override void PostSetupContent()
+        public override void PostSetupRecipes()
         {
             InitializeItems();
         }


### PR DESCRIPTION
`PostSetupContent()` is too early since modded item's names have not be initialized they were omitted from the item panel.